### PR TITLE
Make NPWD data separate for each character

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -4,7 +4,6 @@ RegisterNetEvent("ND_npwd:refresh", function()
     local src = source
     exports["npwd"]:unloadPlayer(src)
     local player = NDCore.Functions.GetPlayer(src)
-    local license = NDCore.Functions.GetPlayerIdentifierFromType("license", src)
     local phoneNumber = player.phoneNumber
     if not phoneNumber then
         phoneNumber = exports.npwd:generatePhoneNumber()
@@ -12,7 +11,7 @@ RegisterNetEvent("ND_npwd:refresh", function()
     end
     exports["npwd"]:newPlayer({
         source = src,
-        identifier = license,
+        identifier = player.id,
         firstname = player.firstName,
         lastname = player.lastName,
         phoneNumber = phoneNumber


### PR DESCRIPTION
This makes NPWD use the player's character ID for their identifier instead of their license, this allows for the players data to be separate across their characters.